### PR TITLE
feat: Add scroll to Top button

### DIFF
--- a/client/src/pages/Companies.jsx
+++ b/client/src/pages/Companies.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { CompanyCard, CustomButton, Header, ListBox } from "../components";
 import { companies } from "../utils/data";
+import { BiArrowToTop } from "react-icons/bi";
 
 const Companies = () => {
   const [page, setPage] = useState(1);
@@ -70,6 +71,8 @@ const Companies = () => {
           </div>
         )}
       </div>
+      {/* Top Scroll Btn */}
+      <BiArrowToTop className="fixed bottom-4 right-4 border rounded-full p-1" size={50} onClick={()=>{window.scrollTo({ top: 0, left: 0, behavior: "smooth"});}}/>
     </div>
   );
 };

--- a/client/src/pages/FindJobs.jsx
+++ b/client/src/pages/FindJobs.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { BiBriefcaseAlt2 } from "react-icons/bi";
+import { BiArrowToTop, BiBriefcaseAlt2 } from "react-icons/bi";
 import { BsStars } from "react-icons/bs";
 import { MdOutlineKeyboardArrowDown } from "react-icons/md";
 
@@ -138,6 +138,8 @@ const FindJobs = () => {
           )}
         </div>
       </div>
+      {/* Top Scroll Btn */}
+      <BiArrowToTop className="fixed bottom-4 right-4 border rounded-full p-1" size={50} onClick={()=>{window.scrollTo({ top: 0, left: 0, behavior: "smooth"});}}/>
     </div>
   );
 };


### PR DESCRIPTION
## Related Issue
When a list of jobs or companies are shown then page size can be lengthy, If  user wanted to go on top then user have to scroll to the top manually.

## Description
I have added the scroll to top button in both the jobs and companies page, to provide the better experience to the users.

## Type of PR

- [X] Feature enhancement

## Screenshots / videos (if applicable)
![Screenshot 2024-05-21 001437](https://github.com/PatilHarshh/Kaam-Do/assets/116253053/1d19d1e9-94ca-43af-bfaf-0b8d9c6c7be4)

## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
