### PR TITLE
Hamburger and cross icons are now visible in every mode.

### DIFF
--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -149,7 +149,7 @@ const Navbar = () => {
           className="block lg:hidden text-slate-900"
           onClick={() => setIsOpen((prev) => !prev)}
         >
-          {isOpen ? <AiOutlineClose size={26} /> : <HiMenuAlt3 size={26} />}
+          {isOpen ? <AiOutlineClose size={26} style={{color:'orange'}}/> : <HiMenuAlt3 size={26} style={{color:'red'}}/>}
         </button>
       </nav>
 


### PR DESCRIPTION
## Related Issue
Solves #299

## Description
Now the hamburger and cross icons are properly visible in light as well as dark mode.
## Type of PR

- [x] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
![Screenshot (526)](https://github.com/PatilHarshh/Kaam-Do/assets/143121854/77a97e0c-189a-40ee-be2f-e4aee0412ae4)
![Screenshot (527)](https://github.com/PatilHarshh/Kaam-Do/assets/143121854/7ef173c5-ce94-4463-98ca-1697cdadf8ec)


## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->
