### PR TITLE
[FEAT]:text-is-not-visible-in-dark-mode

### DIFF
--- a/client/src/pages/blogs.jsx
+++ b/client/src/pages/blogs.jsx
@@ -44,8 +44,8 @@ const BlogGrid = () => {
     boxSizing: 'border-box',
     border: '1px solid #ddd',
     borderRadius: '5px',
-    backgroundColor: '#f9f9f9',
-  };
+    backgroundColor: 'grey',
+  }
 
   const imageStyle = {
     maxWidth: '100%',


### PR DESCRIPTION
Fixed:#301

## Description
In the blog section, the text is not visible in dark mode, as the cards become the white plain background.

## Type of PR

- [ ] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
video-
https://github.com/PatilHarshh/Kaam-Do/assets/155576040/6747afd1-ab25-4953-a3d3-c7fc7f344b69
img-
![Screenshot 2024-06-30 023929](https://github.com/PatilHarshh/Kaam-Do/assets/155576040/f00a6069-9e24-48d4-b35d-0283313c197e)



## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
